### PR TITLE
Fix cookie consent callbacks

### DIFF
--- a/js/cookie.js
+++ b/js/cookie.js
@@ -30,14 +30,14 @@ function openLarge() {
 	$('#cookieDivFull').show(500, 'swing');
 };
 
-function acceptClick() {		
-	$('#cookieDivFull').hide(500, 'swing', openSmall());
-	return false;
+function acceptClick() {
+        $('#cookieDivFull').hide(500, 'swing', openSmall);
+        return false;
 }
 
 function privacyClick() {
-	$('#cookieDivSmall').hide(500, 'swing', openLarge());
-	return false;
+        $('#cookieDivSmall').hide(500, 'swing', openLarge);
+        return false;
 }
 //////////////////////////////////////////
 // End Regular Functions


### PR DESCRIPTION
## Summary
- fix cookie.js to pass callbacks instead of invoking them
- add a trailing newline

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cfeba6aa083308f73c2b78303eb72