### PR TITLE
Fix typos for manufacturer references

### DIFF
--- a/pages/end-uses.html
+++ b/pages/end-uses.html
@@ -217,7 +217,7 @@ function onSubmit(token) {
                         </div>
                         <div class="col-sm-12 col-lg-8">
                             <div class="icon-row__content">
-                            <p>We have many years of experience working with the automotive sector.&nbsp;<span>Many of our projects include manufacturing components that are used by some of the biggest and well known vehicles manufactures in the world.</span></p>
+                            <p>We have many years of experience working with the automotive sector.&nbsp;<span>Many of our projects include manufacturing components that are used by some of the biggest and well known vehicle manufacturers in the world.</span></p>
 <p><strong><span>&nbsp;</span></strong></p>                            </div>
                         </div>
                     </div>
@@ -247,7 +247,7 @@ function onSubmit(token) {
                         </div>
                         <div class="col-sm-12 col-lg-8">
                             <div class="icon-row__content">
-                            <p><span>We have been a leading supplier for manufactured components to the agricultural industry for over 30 years. Our components are currently being used by some of the leading manufactures of agricultural machinery and are used in a variety of machinery such as tractors and trailers.</span></p>                            </div>
+                            <p><span>We have been a leading supplier for manufactured components to the agricultural industry for over 30 years. Our components are currently being used by some of the leading manufacturers of agricultural machinery and are used in a variety of machinery such as tractors and trailers.</span></p>                            </div>
                         </div>
                     </div>
                 </div>
@@ -276,7 +276,7 @@ function onSubmit(token) {
                         </div>
                         <div class="col-sm-12 col-lg-8">
                             <div class="icon-row__content">
-                            <p>One of our key end users is the construction industry. Our components are currently being used by leading manufactures of construction vehicles for over 35 years, and have been used in large variety of construction machinery from diggers to off-highway vehicles. Our reputation for high precision quality components at a competitive price has made us a key supplier in this market.</p>                            </div>
+                            <p>One of our key end users is the construction industry. Our components are currently being used by leading manufacturers of construction vehicles for over 35 years, and have been used in large variety of construction machinery from diggers to off-highway vehicles. Our reputation for high precision quality components at a competitive price has made us a key supplier in this market.</p>                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- fix typos on vehicle, agricultural and construction manufacturer references in `end-uses.html`

## Testing
- `grep -n manufact pages/end-uses.html`

------
https://chatgpt.com/codex/tasks/task_e_684d01319f1c8330a293f5c860f5049e