### PR TITLE
Add Jest test for cookie banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+
+# Logs
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Mantriq
+
+## Testing
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Run tests:
+   ```bash
+   npm test
+   ```
+
+The test suite uses [Jest](https://jestjs.io/) with the `jsdom` environment to execute browser based scripts.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mantriq",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/cookie.test.js
+++ b/tests/cookie.test.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const {JSDOM} = require('jsdom');
+
+describe('cookie banner', () => {
+  let window, document, localStorage;
+
+  beforeEach(() => {
+    const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {url: 'http://localhost'});
+    window = dom.window;
+    document = window.document;
+    localStorage = window.localStorage;
+
+    // minimal jQuery-like helper
+    global.$ = function(sel) {
+      if (sel === document) {
+        return {ready: fn => fn()};
+      }
+      const nodes = document.querySelectorAll(sel);
+      const execCallback = (args) => {
+        for (const arg of args) {
+          if (typeof arg === 'function') { arg(); break; }
+        }
+      };
+      return {
+        show: (...args) => {
+          nodes.forEach(n => { n.style.display = 'block'; });
+          execCallback(args);
+        },
+        hide: (...args) => {
+          nodes.forEach(n => { n.style.display = 'none'; });
+          execCallback(args);
+        }
+      };
+    };
+
+    global.window = window;
+    global.document = document;
+    global.localStorage = localStorage;
+
+    // load script after globals are set
+    require(path.join('..', 'js', 'cookie.js'));
+  });
+
+  afterEach(() => {
+    delete require.cache[require.resolve(path.join('..', 'js', 'cookie.js'))];
+    delete global.$;
+    delete global.window;
+    delete global.document;
+    delete global.localStorage;
+  });
+
+  test('acceptClick stores consent and toggles banners', () => {
+    const fullBanner = document.getElementById('cookieDivFull');
+    const smallBanner = document.getElementById('cookieDivSmall');
+
+    // ensure large banner starts visible
+    expect(fullBanner.style.display).toBe('block');
+    expect(smallBanner.style.display).toBe('none');
+
+    // trigger acceptance
+    window.acceptClick();
+
+    expect(localStorage.getItem('cookiesAllowed')).toBe('yes');
+    expect(fullBanner.style.display).toBe('none');
+    expect(smallBanner.style.display).toBe('block');
+  });
+});


### PR DESCRIPTION
## Summary
- initialize Node project and add Jest + jsdom config
- add a simple README with test instructions
- create a Jest test exercising cookie.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d013495388330a4420bbd453db804